### PR TITLE
update encoding package to remove import errors

### DIFF
--- a/camera/camera_test.go
+++ b/camera/camera_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCamera(t *testing.T) {
-	camera, err := New(Options{0, 0, 640, 480})
+	camera, err := New(Options{0, 0, 640, 480, false})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/cam2ip/main.go
+++ b/cmd/cam2ip/main.go
@@ -53,7 +53,7 @@ func main() {
 		}
 	}
 
-	cam, err := camera.New(camera.Options{srv.Index, srv.Rotate, srv.FrameWidth, srv.FrameHeight, srv.Timestamp})
+	cam, err := camera.New(camera.Options{Index: srv.Index, Rotate: srv.Rotate, Width: srv.FrameWidth, Height: srv.FrameHeight, Timestamp: srv.Timestamp})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad // indirect
 	golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a // indirect
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
-	goost.org/encoding/base64 v0.0.0-20190928151742-cd6f75493c10
 	nhooyr.io/websocket v1.6.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -137,7 +137,6 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190618155005-516e3c20635f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190927073244-c990c680b611 h1:q9u40nxWT5zRClI/uU9dHCiYGottAg6Nzz4YUQyHxdA=
 golang.org/x/sys v0.0.0-20190927073244-c990c680b611/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
@@ -145,8 +144,6 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-goost.org/encoding/base64 v0.0.0-20190928151742-cd6f75493c10 h1:Z4tmKmcuax8bev3BlmNf3/0tcw6j/BBXFY6Hnq0njew=
-goost.org/encoding/base64 v0.0.0-20190928151742-cd6f75493c10/go.mod h1:pBZSqyNgDwqnkoXcbBD1wSOStfw5WgjBx9Zcda9RvLA=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/image/base64_amd64.go
+++ b/image/base64_amd64.go
@@ -3,7 +3,7 @@
 package image
 
 import (
-	"goost.org/encoding/base64"
+	"encoding/base64"
 )
 
 func EncodeToString(src []byte) string {


### PR DESCRIPTION
I was unable to compile the project because of the following error: go: goost.org/encoding/base64@v0.0.0-20190928151742-cd6f75493c10: unrecognized import path "goost.org/encoding/base64": https fetch: Get "https://goost.org/encoding/base64?go-get=1": dial tcp: lookup goost.org: no such host
after reviewing answers from SO and others I found that it the encoding/base64 could be simply replaced with an internal package. The rest is the minor changes, suggested by the IDE checkstyle. 