### PR TITLE
Update html.go: use wss if https is used

### DIFF
--- a/handlers/html.go
+++ b/handlers/html.go
@@ -45,7 +45,11 @@ var html = `<html>
         <meta charset="utf-8"/>
         <title>cam2ip</title>
         <script>
-        ws = new WebSocket("ws://" + window.location.host + "/socket");
+		if (location.protocol === 'https:') {
+  			ws = new WebSocket("wss://" + window.location.host + "/socket");
+		} else {
+  			ws = new WebSocket("ws://" + window.location.host + "/socket");
+		}
         var image = new Image();
 
         ws.onopen = function() {
@@ -78,7 +82,11 @@ var htmlWebGL = `<html>
         <script>
 		var texture, vloc, tloc, vertexBuff, textureBuff;
 
-		ws = new WebSocket("ws://" + window.location.host + "/socket");
+		if (location.protocol === 'https:') {
+  			ws = new WebSocket("wss://" + window.location.host + "/socket");
+		} else {
+  			ws = new WebSocket("ws://" + window.location.host + "/socket");
+		}
 		var image = new Image();
 
 		ws.onopen = function() {


### PR DESCRIPTION
A very simple change to use wss in case that the connection is done through https so /html page will show an image.
If this is not in place and you put the endpoint behind a reverse proxy like nginx with ssl cert enable the browser will complain about security risks and you will see this messages on the logs.

```
sh[151588]: 2025/09/14 15:31:45 socket: accept: failed to accept WebSocket connection: WebSocket protocol violation: handshake request must be at least HTTP/1.1: "HTTP/1.0"
```